### PR TITLE
update example import

### DIFF
--- a/doc/website/blog/2022-02-15-generate-rest-crud-with-ent-and-ogen.md
+++ b/doc/website/blog/2022-02-15-generate-rest-crud-with-ent-and-ogen.md
@@ -62,10 +62,10 @@ package main
 import (
 	"log"
 
+	"ariga.io/ogent"
 	"entgo.io/contrib/entoas"
 	"entgo.io/ent/entc"
 	"entgo.io/ent/entc/gen"
-	"github.com/ariga/ogent"
 	"github.com/ogen-go/ogen"
 )
 


### PR DESCRIPTION
Generator example is importing `github.com/ariga/ogent` instead of `ariga.io/ogent` 